### PR TITLE
Change prefix command shortcut

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,3 +1,8 @@
+# remap command prefix from 'C-b' to 'C-a'
+unbind C-b
+set-option -g prefix C-a
+bind-key C-a send-prefix
+
 set-option -g lock-command vlock
 set-option -g lock-after-time 600
 
@@ -21,7 +26,7 @@ set-option -g pane-active-border-bg black
 set-option -g pane-active-border-fg red
 set-option -g pane-border-style fg=brightblack
 
-# Pane management
+# Pane management - changes keys used for splitting and selecting
 bind-key -n M-c kill-pane
 bind | split-window -h
 bind - split-window -v
@@ -47,7 +52,7 @@ bind-key -n M-r source $HOME/.tmux.conf
 bind-key -n M-y copy-mode
 bind-key -n M-p paste-buffer
 
-# Just to use with vim digraphs :p
+# Just to use with vim digraphs
 bind-key -n M-k send-keys C-k
 
 # Window formatting


### PR DESCRIPTION
Change prefix command from the default C-b to C-a to make it easier on teh hands and more intuitive.